### PR TITLE
Use mb_strlen to support multibyte chars

### DIFF
--- a/src/Table.php
+++ b/src/Table.php
@@ -217,17 +217,16 @@ class Table
      */
     private function getLengths()
     {
-        for ($i = 0; $i < $this->columns; $i++) {
-            $this->maxLength[$i] = 0;
-
-            //headers
-            foreach ($this->header as $field) {
-
-                //set initial max lengths to the length of each header cell
-                if (mb_strlen($field) > $this->maxLength[$i]) {
-                    $this->maxLength[$i] = mb_strlen($field);
-                }
+        //headers
+        $i = 0;
+        foreach ($this->header as $field) {
+            //set initial max lengths to the length of each header cell
+            if (!isset($this->maxLength[$i])) {
+                $this->maxLength[$i] = mb_strlen($field);
+            } elseif (mb_strlen($field) > $this->maxLength[$i]) {
+                $this->maxLength[$i] = mb_strlen($field);
             }
+            ++$i;
         }
 
         //data
@@ -238,7 +237,7 @@ class Table
                 if (mb_strlen($field) > $this->maxLength[$i]) {
                     $this->maxLength[$i] = mb_strlen($field);
                 }
-                $i++;
+                ++$i;
             }
         }
     }

--- a/src/Table.php
+++ b/src/Table.php
@@ -1,22 +1,22 @@
 <?php
 
-/*
+/**
  * This file is part of the Miloske85\php-cli-table project
  *
  * Copyright 2016 Milos Milutinovic <milos.milutinovic@live.com>
  *
- *  This program is free software: you can redistribute it and/or modify
- *  it under the terms of the GNU General Public License as published by
- *  the Free Software Foundation, either version 3 of the License, or
- *  (at your option) any later version.
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
  *
- *  This program is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- *  GNU General Public License for more details.
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
  *
- *  You should have received a copy of the GNU General Public License
- *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
 namespace Miloske85\php_cli_table;
@@ -24,66 +24,73 @@ namespace Miloske85\php_cli_table;
 /**
  * Genarates formatted tables for CLI output
  */
-class Table {
+class Table
+{
 
     /**
      * Table header, array of names
+     *
      * @var array
      */
-    private $header = array();
+    private $header = [];
 
     /**
      * Data for the table, array of arrays (rows)
+     *
      * @var array of arrays
      */
-    private $data = array();
+    private $data = [];
 
     /**
      * Maximum length of each column
+     *
      * @var array if ints
      */
-    private $maxLength = array();
+    private $maxLength = [];
 
     /**
      * Number of columns
+     *
      * @var int
      */
     private $columns;
 
     /**
      * Line at the start and the end of the table
+     *
      * @var string
      */
     private $line;
 
     /**
      * The final table
+     *
      * @var string
      */
     private $table;
 
     /**
-     *
      * @param array $data Array of arrays or objects
      * @param array $header Table header [optional]
-     * 
-     * Table expects $data to be either array of objects or array of arrays. In 
+     *
+     * Table expects $data to be either array of objects or array of arrays. In
      * case array of numerically indexed arrays is used, header array must be
      * passed, because the script has no way to generate table header. $header
      * can also be used for passing custom table headers.
+     * @throws \Exception
      */
-    public function __construct($data, $header = null){
-        
+    public function __construct($data, $header = null)
+    {
         $this->data = $data;
-        
+
         $header ? $this->header = $header : $this->header = null;
 
-        $header? $this->columns = count($header) : $this->columns = null;
-        
+        $header ? $this->columns = count($header) : $this->columns = null;
+
         $this->prepareData();
-        
+
         $this->verifyHeader();
-      
+
         $this->verifyData();
 
         $this->getLengths();
@@ -97,53 +104,58 @@ class Table {
      *
      * @return string
      */
-    public function getTable(){
+    public function getTable()
+    {
         return $this->table;
     }
-    
+
     //==========================================================================
     // Private methods
     //==========================================================================
 
-    private function prepareData(){
-        if(!is_array($this->data)){
+    /**
+     * @throws \Exception
+     */
+    private function prepareData()
+    {
+        if (!is_array($this->data)) {
             throw new \Exception('Data passed must be an array');
         }
-        
-        if(is_object($this->data[0])){
+
+        if (is_object($this->data[0])) {
             $this->generateHeaderFromData();
             $this->convertObjectToArray();
-        }
-        elseif(is_array($this->data[0])){
+        } elseif (is_array($this->data[0])) {
             $this->generateHeaderFromData();
-        }
-        else{
+        } else {
             throw new \Exception('Passed data must be array of objects or arrays');
         }
     }
-    
-    private function convertObjectToArray(){
-        $temp = array();
-        
-        foreach($this->data as $obj){
-            $arr = array();
-            
-            foreach($obj as $item){
+
+    private function convertObjectToArray()
+    {
+        $temp = [];
+
+        foreach ($this->data as $obj) {
+            $arr = [];
+
+            foreach ($obj as $item) {
                 $arr[] = $item;
             }
-            
+
             $temp[] = $arr;
         }
-        
+
         $this->data = $temp;
     }
-    
-    private function generateHeaderFromData(){
-        //do not overwrite
-        if(!$this->header){
-            $temp = array();
 
-            foreach($this->data[0] as $key => $item){
+    private function generateHeaderFromData()
+    {
+        //do not overwrite
+        if (!$this->header) {
+            $temp = [];
+
+            foreach ($this->data[0] as $key => $item) {
                 $temp[] = $key;
             }
 
@@ -152,29 +164,29 @@ class Table {
             $this->columns = count($temp);
         }
     }
-    
-    private function generateHeader(){
 
+    private function generateHeader()
+    {
         $table = '';
 
         //starting line
-        for($i=0; $i<$this->columns; $i++){
+        for ($i = 0; $i < $this->columns; $i++) {
             $table .= '+';
             $len = $this->maxLength[$i] + 2; //ensures that the longest string has a space after it
-            $table .= sprintf("%'-{$len}s",'');
+            $table .= sprintf("%'-{$len}s", '');
         }
-        $table .= '+'.PHP_EOL;
+        $table .= '+' . PHP_EOL;
 
         $this->line = $table; //the first and the last line of the header
 
         //column names
-        for($i=0; $i<$this->columns; $i++){
+        for ($i = 0; $i < $this->columns; $i++) {
             $len = $this->maxLength[$i] + 1; //ensures that the longest string has a space after it
             $table .= '| ';
-            $table .= sprintf("%' -{$len}s",$this->header[$i]);
+            $table .= sprintf("%' -{$len}s", $this->header[$i]);
         }
 
-        $table .= '|'.PHP_EOL;
+        $table .= '|' . PHP_EOL;
 
         //add the ending line
         $table .= $this->line;
@@ -182,17 +194,18 @@ class Table {
         $this->table = $table;
     }
 
-    private function generateBody(){
+    private function generateBody()
+    {
         $table = '';
 
-        foreach($this->data as $row){
+        foreach ($this->data as $row) {
             $i = 0;
-            foreach($row as $field){
+            foreach ($row as $field) {
                 $len = $this->maxLength[$i] + 1; //ensures that the longest string has a space after it
-                $table .= '| '.sprintf("%' -{$len}s",$field);
+                $table .= '| ' . sprintf("%' -{$len}s", $field);
                 $i++;
             }
-            $table .= '|'.PHP_EOL;
+            $table .= '|' . PHP_EOL;
         }
 
         $this->table .= $table;
@@ -202,61 +215,64 @@ class Table {
     /**
      * Find maximum lengths for each column
      */
-    private function getLengths(){
-
-        for($i=0; $i<$this->columns; $i++){
+    private function getLengths()
+    {
+        for ($i = 0; $i < $this->columns; $i++) {
             $this->maxLength[$i] = 0;
 
             //headers
-            foreach($this->header as $field){
+            foreach ($this->header as $field) {
 
                 //set initial max lengths to the length of each header cell
-                if(strlen($field) > $this->maxLength[$i]){
-                    $this->maxLength[$i] = strlen($field);
+                if (mb_strlen($field) > $this->maxLength[$i]) {
+                    $this->maxLength[$i] = mb_strlen($field);
                 }
             }
         }
 
-            //data
-        foreach($this->data as $row){
+        //data
+        foreach ($this->data as $row) {
             //test each field in each row
-            $i=0;
-            foreach($row as $field){
-                if(strlen($field) > $this->maxLength[$i]){
-                    $this->maxLength[$i] = strlen($field);
+            $i = 0;
+            foreach ($row as $field) {
+                if (mb_strlen($field) > $this->maxLength[$i]) {
+                    $this->maxLength[$i] = mb_strlen($field);
                 }
                 $i++;
             }
-
         }
-
     }
 
     /**
-    *   Checks that table header is an array
-    */
-    private function verifyHeader(){
-        if(!is_array($this->header)){
+     * Checks that table header is an array
+     *
+     * @throws \Exception
+     */
+    private function verifyHeader()
+    {
+        if (!is_array($this->header)) {
             throw new \Exception('Table header must be an array');
         }
     }
 
     /**
-    *  Verifies that data passed is an array and that it matches the array
-    *   passed to header
-    */
-    private function verifyData(){
-        if(!is_array($this->data)){
+     * Verifies that data passed is an array and that it matches the array
+     * passed to header
+     *
+     * @throws \Exception
+     */
+    private function verifyData()
+    {
+        if (!is_array($this->data)) {
             throw new \Exception('Data passed must be an array');
         }
 
-        if(!is_array($this->data[0])){
+        if (!is_array($this->data[0])) {
             throw new \Exception('Data must be an array of arrays');
         }
 
-        if(count($this->data[0]) != $this->columns){
+        if (count($this->data[0]) != $this->columns) {
             throw new \Exception('Array length mismatch between table header and the data');
         }
     }
-    
 }


### PR DESCRIPTION
This fixes an issue when you use multibyte characters as well in your table like:

```
+------------+
| Zip        |
+------------+
| 72336 X    |
| 78532 ✔    |
+------------+
```

The second fix is to use independent widths of each column (before they all had the same width)